### PR TITLE
fix: unexpected token 'export' and typos

### DIFF
--- a/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -64,8 +64,7 @@ export declare function $path(
 `;
 
 exports[`build 2`] = `
-"
-const routes = {
+"const routes = {
   \\"/chats/:season/:episode/:slug\\": [
     \\"season\\",
     \\"episode\\",
@@ -95,26 +94,31 @@ const routes = {
   ]
 };
 
-export function $path(route, ...paramsOrQuery) {
-  const { paramsNames } = routesInfo[route];
+function $path(route, ...paramsOrQuery) {
+  const routeParams = routes[route];
   let path = route;
   let query = paramsOrQuery[0];
-  if (paramsNames.length > 0) {
+
+  if (routeParams?.paramsNames?.length > 0) {
     const params = paramsOrQuery[0];
-    let query = paramsOrQuery[1];
-    paramsNames.forEach((name, index) => {
+    paramsNames.forEach((name) => {
       path.replace(':' + name, params[name]);
-    }
+    })
   }
+
   if (!query) {
     return path;
   }
+
   const searchParams = new URLSearchParams('');
   Object.entries(query).forEach(([key, value]) => {
     searchParams.append(key, value);
   });
+
   return path + '?' + searchParams.toString();
 }
+
+module.exports = { $path }
 "
 `;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,7 @@ function generateHelpers(routesInfo: RoutesInfo) {
   return `
 const routes = ${JSON.stringify(routesInfo, null, 2)};
 
-export function $path(route, ...paramsOrQuery) {
+function $path(route, ...paramsOrQuery) {
   const { paramsNames } = routes[route];
   let path = route;
   let query = paramsOrQuery[0];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,15 +81,15 @@ function generateHelpers(routesInfo: RoutesInfo) {
 const routes = ${JSON.stringify(routesInfo, null, 2)};
 
 export function $path(route, ...paramsOrQuery) {
-  const { paramsNames } = routesInfo[route];
+  const { paramsNames } = routes[route];
   let path = route;
   let query = paramsOrQuery[0];
-  if (paramsNames.length > 0) {
+  if (paramsNames?.length > 0) {
     const params = paramsOrQuery[0];
     let query = paramsOrQuery[1];
-    paramsNames.forEach((name, index) => {
+    paramsNames?.forEach((name, index) => {
       path.replace(':' + name, params[name]);
-    }
+    })
   }
   if (!query) {
     return path;
@@ -100,6 +100,8 @@ export function $path(route, ...paramsOrQuery) {
   });
   return path + '?' + searchParams.toString();
 }
+
+module.exports = { $path }
 `;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,27 +77,29 @@ function generate(routesInfo: RoutesInfo) {
 }
 
 function generateHelpers(routesInfo: RoutesInfo) {
-  return `
-const routes = ${JSON.stringify(routesInfo, null, 2)};
+  return `const routes = ${JSON.stringify(routesInfo, null, 2)};
 
 function $path(route, ...paramsOrQuery) {
-  const { paramsNames } = routes[route];
+  const routeParams = routes[route];
   let path = route;
   let query = paramsOrQuery[0];
-  if (paramsNames?.length > 0) {
+
+  if (routeParams?.paramsNames?.length > 0) {
     const params = paramsOrQuery[0];
-    let query = paramsOrQuery[1];
-    paramsNames?.forEach((name, index) => {
+    paramsNames.forEach((name) => {
       path.replace(':' + name, params[name]);
     })
   }
+
   if (!query) {
     return path;
   }
+
   const searchParams = new URLSearchParams('');
   Object.entries(query).forEach(([key, value]) => {
     searchParams.append(key, value);
   });
+
   return path + '?' + searchParams.toString();
 }
 


### PR DESCRIPTION
This PR fixes four things:

- The `Unexpected token 'export'` error from https://github.com/yesmeck/remix-routes/issues/4
- The error that the function was reading `routesInfo[route]` instead of `routes[route]`
- And a missing closing parenthesis in the `forEach` 
- Check that `routeParams` is not undefined and have `paramsNames` before use it