### PR TITLE
feat: support URLSearchParams init as param

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ import { $path } from 'remix-routes';
 
 $path('/posts/:id', { id: 6 }, { version: 18 }); // => /posts/6?version=18
 $path('/posts', { limit: 10 }); // => /posts?limit=10
+// You can pass any URLSearchParams init as param
+$path('/posts/delete', [['id', 1], ['id', 2]]); // => /posts/delete?id=1&id=2
 ```
 
 Checking params:

--- a/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -42,79 +42,79 @@ exports[`build 2`] = `"{\\"name\\":\\".remix-routes\\",\\"main\\":\\"index.js\\"
 exports[`build 3`] = `
 "export declare function $path(
   route: \\"/\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/chats/:season/:episode/:slug\\",
   params: { season: string | number; episode: string | number; slug: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/chats/:season/:episode\\",
   params: { season: string | number; episode: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/people/:personId\\",
   params: { personId: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/people/:personId/:planId/remove-plan\\",
   params: { personId: string | number; planId: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/blog/rss.xml\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/auth\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/auth/login\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/s/:query\\",
   params: { query: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/credits\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/admin\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/admin/episodes\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/:id\\",
   params: { id: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/:id/comments\\",
   params: { id: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/new\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/jokes\\",
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 export declare function $path(
   route: \\"/jokes/:jokeId\\",
   params: { jokeId: string | number },
-  query?: Record<string, string | number>
+  query?: string | string[][] | Record<string, string> | URLSearchParams
 ): string;
 
 export declare function $params(

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -12,6 +12,15 @@ test('$path + query', () => {
   expect($path('/posts', { order: 'desc' })).toBe('/posts?order=desc');
 });
 
+test('$path + array query', () => {
+  expect(
+    $path('/posts/delete', [
+      ['id', 1],
+      ['id', 2],
+    ]),
+  ).toBe('/posts/delete?id=1&id=2');
+});
+
 test('$path + params + query', () => {
   expect($path('/posts/:id', { id: 1 }, { raw: 'true' })).toBe('/posts/1?raw=true');
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,7 +136,9 @@ function generatePathDefinition(routesInfo: RoutesInfo) {
       );
       lines.push(`  params: { ${paramsType.join('; ')} },`);
     }
-    lines.push(`  query?: Record<string, string | number>`);
+    lines.push(
+      `  query?: string | string[][] | Record<string, string> | URLSearchParams`,
+    );
     lines.push(`): string;`);
     code.push(lines.join('\n'));
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,28 @@
 import { routes } from '.remix-routes';
 
-export function $path(route: string, ...paramsOrQuery: Array<object>) {
+export function $path(route: string, ...paramsOrQuery: Array<any>) {
   const routeParams = routes[route];
   let path = route;
-  let query = paramsOrQuery[0];
+  let query:
+    | string
+    | string[][]
+    | Record<string, string>
+    | URLSearchParams
+    | undefined = paramsOrQuery[0];
 
   if (routeParams?.length > 0) {
     const params: any = paramsOrQuery[0];
     query = paramsOrQuery[1];
     routeParams.forEach((name) => {
       path = path.replace(':' + name, params[name]);
-    })
+    });
   }
 
   if (!query) {
     return path;
   }
 
-  const searchParams = new URLSearchParams('');
-
-  Object.entries(query).forEach(([key, value]) => {
-    searchParams.append(key, value);
-  });
+  const searchParams = new URLSearchParams(query);
 
   return path + '?' + searchParams.toString();
 }


### PR DESCRIPTION
close #17

Example:

```typescript
$path('/posts/delete', [['id', 1], ['id', 2]]); // => /posts/delete?id=1&id=2
```