### PR TITLE
feat: add outputDirPath arg to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ export const action: ActionFunction = async ({ params }) => {
 ## Command Line Options
 
 - `-w`: Watch for changes and automatically rebuild.
+- `-o`: Specify the output path for `remix-routes.d.ts`. Defaults to `./node_modules` if arg is not given.
 
 ## TypeScript Integration
 

--- a/packages/remix-routes/src/__tests__/cli.test.ts
+++ b/packages/remix-routes/src/__tests__/cli.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { build } from '../cli';
 
 test('build', async () => {
-  await build(path.resolve(__dirname, '../../fixture'));
+  await build(path.resolve(__dirname, '../../fixture'), 'node_modules');
   expect(
     fs.readFileSync(path.resolve(__dirname, '../../fixture/node_modules/remix-routes.d.ts'), 'utf8'),
   ).toMatchSnapshot();

--- a/packages/remix-routes/src/__tests__/cli.test.ts
+++ b/packages/remix-routes/src/__tests__/cli.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { build } from '../cli';
 
 test('build', async () => {
-  await build(path.resolve(__dirname, '../../fixture'), 'node_modules');
+  await build(path.resolve(__dirname, '../../fixture'), './node_modules');
   expect(
     fs.readFileSync(path.resolve(__dirname, '../../fixture/node_modules/remix-routes.d.ts'), 'utf8'),
   ).toMatchSnapshot();

--- a/packages/remix-routes/src/cli.ts
+++ b/packages/remix-routes/src/cli.ts
@@ -31,7 +31,7 @@ const cli = meow(helpText, {
     outputDirPath: {
       type: 'string',
       alias: 'o',
-      default: 'node_modules',
+      default: './node_modules',
     }
   },
 });

--- a/packages/remix-routes/src/cli.ts
+++ b/packages/remix-routes/src/cli.ts
@@ -28,6 +28,11 @@ const cli = meow(helpText, {
       type: 'boolean',
       alias: 'w',
     },
+    outputDirPath: {
+      type: 'string',
+      alias: 'o',
+      default: 'node_modules',
+    }
   },
 });
 
@@ -72,25 +77,25 @@ async function buildHelpers(remixRoot: string): Promise<RoutesInfo> {
   return routesInfo;
 }
 
-export async function build(remixRoot: string) {
+export async function build(remixRoot: string, outputDirPath: string) {
   const routesInfo = await buildHelpers(remixRoot);
-  generate(routesInfo, remixRoot);
+  generate(routesInfo, remixRoot, outputDirPath);
 }
 
-function watch(remixRoot: string) {
-  build(remixRoot);
+function watch(remixRoot: string, outputDirPath: string) {
+  build(remixRoot, outputDirPath);
   chokidar
     .watch([
       path.join(remixRoot, 'app/routes/**/*.{ts,tsx}'),
       path.join(remixRoot, 'remix.config.js'),
     ])
     .on('change', () => {
-      build(remixRoot);
+      build(remixRoot, outputDirPath);
     });
   console.log('Watching for routes changes...');
 }
 
-function generate(routesInfo: RoutesInfo, remixRoot: string) {
+function generate(routesInfo: RoutesInfo, remixRoot: string, outputDirPath: string) {
   const tsCode =
     [
       `
@@ -108,7 +113,7 @@ type Query<T> = IsAny<T> extends true ? [URLSearchParamsInit?] : [T];
 
   const outputPath = path.join(
     remixRoot,
-    'node_modules',
+    outputDirPath,
   );
 
   if (!fs.existsSync(outputPath)) {
@@ -184,9 +189,9 @@ if (require.main === module) {
     const remixRoot = process.env.REMIX_ROOT || process.cwd();
 
     if (cli.flags.watch) {
-      watch(remixRoot);
+      watch(remixRoot, cli.flags.outputDirPath);
     } else {
-      build(remixRoot);
+      build(remixRoot, cli.flags.outputDirPath);
     }
   })();
 }


### PR DESCRIPTION
### What
- Provide an arg to set a custom output path for remix-routes.d.ts

### Why
- For our remix project, we have specific folders where builds and types end up. As such, it would be helpful to be able to specify an output path other than `node_modules`. This should also be relevant to others who are using remix-routes.