### PR TITLE
fix: enable remix-routes.d.ts to find remix-routes module

### DIFF
--- a/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`build 1`] = `
 "
+declare module \\"remix-routes\\" {
+
 type IsAny<T> = (
   unknown extends T
     ? [keyof T] extends [never] ? false : true
@@ -170,6 +172,8 @@ export declare function $params(
 ): {
   jokeId: string
 };
+
+}
 
 "
 `;

--- a/packages/remix-routes/src/cli.ts
+++ b/packages/remix-routes/src/cli.ts
@@ -22,6 +22,8 @@ Options
 --watch, -w  Watch for routes changes
 `;
 
+const DEFAULT_OUTPUT_DIR_PATH = './node_modules'
+
 const cli = meow(helpText, {
   flags: {
     watch: {
@@ -31,7 +33,7 @@ const cli = meow(helpText, {
     outputDirPath: {
       type: 'string',
       alias: 'o',
-      default: './node_modules',
+      default: DEFAULT_OUTPUT_DIR_PATH,
     }
   },
 });
@@ -99,6 +101,8 @@ function generate(routesInfo: RoutesInfo, remixRoot: string, outputDirPath: stri
   const tsCode =
     [
       `
+declare module "remix-routes" {
+
 type IsAny<T> = (
   unknown extends T
     ? [keyof T] extends [never] ? false : true
@@ -109,6 +113,7 @@ type Query<T> = IsAny<T> extends true ? [URLSearchParamsInit?] : [T];
       `,
       generatePathDefinition(routesInfo),
       generateParamsDefinition(routesInfo),
+      "}",
     ].join('\n\n') + '\n\n';
 
   const outputPath = path.join(

--- a/packages/remix-routes/src/cli.ts
+++ b/packages/remix-routes/src/cli.ts
@@ -20,6 +20,7 @@ $ remix-routes
 
 Options
 --watch, -w  Watch for routes changes
+--outputDirPath, -o Specify the output path for "remix-routes.d.ts". Defaults to "./node_modules" if arg is not given.
 `;
 
 const DEFAULT_OUTPUT_DIR_PATH = './node_modules'


### PR DESCRIPTION
### Why
- The [previous PR](https://github.com/yesmeck/remix-routes/pull/31) I made resolved a TS completion issue that was faced when `remix-routes.d.ts` was built in another directory. However, there was an issue with `remix-routes.d.ts` getting a reference to the remix-routes module for `$path` and $params` methods. Adding `declare module "remix-routes` resolves that.
- Adding `declare module "remix-routes"` works even if `remix-routes.d.ts` remains in `./node_modules`

Reference: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#testing-your-types
- Refer to the `otherwise` option

Previous, related PR: https://github.com/yesmeck/remix-routes/pull/31