### PR TITLE
breaking: set remix-routes.d.ts in node module

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ export const action: ActionFunction = async ({ params }) => {
 ## Command Line Options
 
 - `-w`: Watch for changes and automatically rebuild.
-- `-o`: Specify the output path for `remix-routes.d.ts`. Defaults to `./node_modules` if arg is not given.
 
 ## TypeScript Integration
 

--- a/packages/remix-routes/package.json
+++ b/packages/remix-routes/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "Typesafe routing for Remix apps.",
   "main": "lib/index.js",
+  "types": "remix-routes.d.ts",
   "bin": {
     "remix-routes": "lib/cli.js"
   },

--- a/packages/remix-routes/src/__tests__/cli.test.ts
+++ b/packages/remix-routes/src/__tests__/cli.test.ts
@@ -4,8 +4,8 @@ import * as path from 'path';
 import { build } from '../cli';
 
 test('build', async () => {
-  await build(path.resolve(__dirname, '../../fixture'), './node_modules');
+  await build(path.resolve(__dirname, '../../fixture'));
   expect(
-    fs.readFileSync(path.resolve(__dirname, '../../fixture/node_modules/remix-routes.d.ts'), 'utf8'),
+    fs.readFileSync(path.resolve(__dirname, '../../fixture/node_modules/remix-routes/remix-routes.d.ts'), 'utf8'),
   ).toMatchSnapshot();
 });

--- a/packages/remix-routes/src/cli.ts
+++ b/packages/remix-routes/src/cli.ts
@@ -28,11 +28,6 @@ const cli = meow(helpText, {
       type: 'boolean',
       alias: 'w',
     },
-    outputDirPath: {
-      type: 'string',
-      alias: 'o',
-      default: './node_modules',
-    }
   },
 });
 
@@ -77,25 +72,25 @@ async function buildHelpers(remixRoot: string): Promise<RoutesInfo> {
   return routesInfo;
 }
 
-export async function build(remixRoot: string, outputDirPath: string) {
+export async function build(remixRoot: string) {
   const routesInfo = await buildHelpers(remixRoot);
-  generate(routesInfo, remixRoot, outputDirPath);
+  generate(routesInfo, remixRoot);
 }
 
-function watch(remixRoot: string, outputDirPath: string) {
-  build(remixRoot, outputDirPath);
+function watch(remixRoot: string) {
+  build(remixRoot);
   chokidar
     .watch([
       path.join(remixRoot, 'app/routes/**/*.{ts,tsx}'),
       path.join(remixRoot, 'remix.config.js'),
     ])
     .on('change', () => {
-      build(remixRoot, outputDirPath);
+      build(remixRoot);
     });
   console.log('Watching for routes changes...');
 }
 
-function generate(routesInfo: RoutesInfo, remixRoot: string, outputDirPath: string) {
+function generate(routesInfo: RoutesInfo, remixRoot: string) {
   const tsCode =
     [
       `
@@ -113,7 +108,7 @@ type Query<T> = IsAny<T> extends true ? [URLSearchParamsInit?] : [T];
 
   const outputPath = path.join(
     remixRoot,
-    outputDirPath,
+    "node_modules/remix-routes",
   );
 
   if (!fs.existsSync(outputPath)) {
@@ -189,9 +184,9 @@ if (require.main === module) {
     const remixRoot = process.env.REMIX_ROOT || process.cwd();
 
     if (cli.flags.watch) {
-      watch(remixRoot, cli.flags.outputDirPath);
+      watch(remixRoot);
     } else {
-      build(remixRoot, cli.flags.outputDirPath);
+      build(remixRoot);
     }
   })();
 }


### PR DESCRIPTION
 ### This PR is for discussion and for showing of an example.

Earlier PRs made #31 , #33 were done to support outputting `remix-routes.d.ts` to a custom directory where the types and functions could be discovered by TS as the default directory of `./node_modules` didn't work for the project I was working on. 

However, another approach for consideration is to build `remix-routes.d.ts` in `./node_modules/remix-routes` instead and then add `"types": "remix-routes.d.ts"` into `package.json`.
- I believe this would be more aligned with the convention for TS projects.
- This would also cause breaking changes for existing users of the package.

We can also consider updating the packages.json while keeping the default output of `remix-routes.d.ts` in `./node_modules` but introduce a different argument in CLI to set `remix-routes.d.ts` in `./node_modules/remix-routes`. This can also work to support backwards compatibility.

Let me know your thoughts and I can work on that.