### PR TITLE
feature: exports route definitions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [14.x, 16.x, 18.x, 19.x]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ export const action: ActionFunction = async ({ params }) => {
 }
 ```
 
+### Route type definitions
+
+remix-routes also export all route type definitions for your convenience.
+
+```typescript
+import type { Routes } from 'remix-routes';
+import { useParams } from "remix";
+
+export default function Component() {
+  const { id } = useParams<Routes['/posts/:id']['params']>();
+  ...
+}
+```
+
 ## Command Line Options
 
 - `-w`: Watch for changes and automatically rebuild.

--- a/e2e/app/routes/index.tsx
+++ b/e2e/app/routes/index.tsx
@@ -1,5 +1,21 @@
 import { $params, $path } from 'remix-routes';
 
+import { Routes } from 'remix-routes';
+import { redirect as remixRedirect } from "@remix-run/node";
+
+function redirect<
+  R extends keyof Routes,
+  P extends Routes[R]["params"],
+  Q extends Routes[R]["query"]
+>(route: R, params: P, query?: Q) {
+  const includeParams = route.indexOf('/:') > -1;
+  return remixRedirect(
+      includeParams ? $path(route as any, params as any, query as any) : $path(route as any, query as any)
+  );
+}
+
+redirect("/posts/:id", { id: 1 }, { view: "list", sort: "price" });
+
 $path('/posts/:id', { id: 1 }, { view: 'list', sort: 'price' });
 
 $path('/', { foo: 'bar' });

--- a/packages/remix-routes/package.json
+++ b/packages/remix-routes/package.json
@@ -38,6 +38,7 @@
     "chokidar": "^3.5.2",
     "meow": "9.0.0",
     "mkdirp": "^1.0.4",
+    "slash": "3",
     "typescript-remix-routes-plugin": "workspace:*"
   },
   "repository": {

--- a/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -13,99 +13,186 @@ type URLSearchParamsInit = string | string[][] | Record<string, string> | URLSea
 type Query<T> = IsAny<T> extends true ? [URLSearchParamsInit?] : [T];
       
 
+export interface Routes {
+  \\"/\\": {
+    params: {  },
+    query: Query<import('../app/root').SearchParams>,
+  };
+  \\"/chats/:season/:episode/:slug\\": {
+    params: { season: string | number; episode: string | number; slug: string | number },
+    query: Query<import('../app/routes/chats.$season.$episode.$slug').SearchParams>,
+  };
+  \\"/chats/:season/:episode\\": {
+    params: { season: string | number; episode: string | number },
+    query: Query<import('../app/routes/chats.$season.$episode').SearchParams>,
+  };
+  \\"/people/:personId\\": {
+    params: { personId: string | number },
+    query: Query<import('../app/routes/people/$personId').SearchParams>,
+  };
+  \\"/people/:personId/:planId/remove-plan\\": {
+    params: { personId: string | number; planId: string | number },
+    query: Query<import('../app/routes/people/$personId/$planId/remove-plan').SearchParams>,
+  };
+  \\"/blog/rss.xml\\": {
+    params: {  },
+    query: Query<import('../app/routes/blog.rss[.]xml').SearchParams>,
+  };
+  \\"/:lang?/about\\": {
+    params: { lang?: string | number },
+    query: Query<import('../app/routes/($lang)/about').SearchParams>,
+  };
+  \\"/posts/delete\\": {
+    params: {  },
+    query: Query<import('../app/routes/posts/delete').SearchParams>,
+  };
+  \\"/auth\\": {
+    params: {  },
+    query: Query<import('../app/routes/auth/__auth').SearchParams>,
+  };
+  \\"/auth/login\\": {
+    params: {  },
+    query: Query<import('../app/routes/auth/__auth/login').SearchParams>,
+  };
+  \\"/posts\\": {
+    params: {  },
+    query: Query<import('../app/routes/posts/index').SearchParams>,
+  };
+  \\"/posts/:id\\": {
+    params: { id: string | number },
+    query: Query<import('../app/routes/posts/$id').SearchParams>,
+  };
+  \\"/s/:query\\": {
+    params: { query: string | number },
+    query: Query<import('../app/routes/s.$query').SearchParams>,
+  };
+  \\"/credits\\": {
+    params: {  },
+    query: Query<import('../app/routes/credits').SearchParams>,
+  };
+  \\"/admin\\": {
+    params: {  },
+    query: Query<import('../app/routes/admin').SearchParams>,
+  };
+  \\"/admin/episodes\\": {
+    params: {  },
+    query: Query<import('../app/routes/admin/episodes/index').SearchParams>,
+  };
+  \\"/admin/episodes/:id\\": {
+    params: { id: string | number },
+    query: Query<import('../app/routes/admin/episodes/$id').SearchParams>,
+  };
+  \\"/admin/episodes/:id/comments\\": {
+    params: { id: string | number },
+    query: Query<import('../app/routes/admin/episodes/$id/comments').SearchParams>,
+  };
+  \\"/admin/episodes/new\\": {
+    params: {  },
+    query: Query<import('../app/routes/admin/episodes/new').SearchParams>,
+  };
+  \\"/jokes\\": {
+    params: {  },
+    query: Query<import('../app/routes/jokes').SearchParams>,
+  };
+  \\"/jokes/:jokeId\\": {
+    params: { jokeId: string | number },
+    query: Query<import('../app/routes/jokes/$jokeId').SearchParams>,
+  };
+}
+
 export declare function $path(
   route: \\"/\\",
-  ...query: Query<import('../app/root').SearchParams>
+  ...query: Routes[\\"/\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/chats/:season/:episode/:slug\\",
-  params: { season: string | number; episode: string | number; slug: string | number },
-  ...query: Query<import('../app/routes/chats.$season.$episode.$slug').SearchParams>
+  params: Routes[\\"/chats/:season/:episode/:slug\\"][\\"params\\"],
+  ...query: Routes[\\"/chats/:season/:episode/:slug\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/chats/:season/:episode\\",
-  params: { season: string | number; episode: string | number },
-  ...query: Query<import('../app/routes/chats.$season.$episode').SearchParams>
+  params: Routes[\\"/chats/:season/:episode\\"][\\"params\\"],
+  ...query: Routes[\\"/chats/:season/:episode\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/people/:personId\\",
-  params: { personId: string | number },
-  ...query: Query<import('../app/routes/people/$personId').SearchParams>
+  params: Routes[\\"/people/:personId\\"][\\"params\\"],
+  ...query: Routes[\\"/people/:personId\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/people/:personId/:planId/remove-plan\\",
-  params: { personId: string | number; planId: string | number },
-  ...query: Query<import('../app/routes/people/$personId/$planId/remove-plan').SearchParams>
+  params: Routes[\\"/people/:personId/:planId/remove-plan\\"][\\"params\\"],
+  ...query: Routes[\\"/people/:personId/:planId/remove-plan\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/blog/rss.xml\\",
-  ...query: Query<import('../app/routes/blog.rss[.]xml').SearchParams>
+  ...query: Routes[\\"/blog/rss.xml\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/:lang?/about\\",
-  params: { lang?: string | number },
-  ...query: Query<import('../app/routes/($lang)/about').SearchParams>
+  params: Routes[\\"/:lang?/about\\"][\\"params\\"],
+  ...query: Routes[\\"/:lang?/about\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/posts/delete\\",
-  ...query: Query<import('../app/routes/posts/delete').SearchParams>
+  ...query: Routes[\\"/posts/delete\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/auth\\",
-  ...query: Query<import('../app/routes/auth/__auth').SearchParams>
+  ...query: Routes[\\"/auth\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/auth/login\\",
-  ...query: Query<import('../app/routes/auth/__auth/login').SearchParams>
+  ...query: Routes[\\"/auth/login\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/posts\\",
-  ...query: Query<import('../app/routes/posts/index').SearchParams>
+  ...query: Routes[\\"/posts\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/posts/:id\\",
-  params: { id: string | number },
-  ...query: Query<import('../app/routes/posts/$id').SearchParams>
+  params: Routes[\\"/posts/:id\\"][\\"params\\"],
+  ...query: Routes[\\"/posts/:id\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/s/:query\\",
-  params: { query: string | number },
-  ...query: Query<import('../app/routes/s.$query').SearchParams>
+  params: Routes[\\"/s/:query\\"][\\"params\\"],
+  ...query: Routes[\\"/s/:query\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/credits\\",
-  ...query: Query<import('../app/routes/credits').SearchParams>
+  ...query: Routes[\\"/credits\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/admin\\",
-  ...query: Query<import('../app/routes/admin').SearchParams>
+  ...query: Routes[\\"/admin\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes\\",
-  ...query: Query<import('../app/routes/admin/episodes/index').SearchParams>
+  ...query: Routes[\\"/admin/episodes\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/:id\\",
-  params: { id: string | number },
-  ...query: Query<import('../app/routes/admin/episodes/$id').SearchParams>
+  params: Routes[\\"/admin/episodes/:id\\"][\\"params\\"],
+  ...query: Routes[\\"/admin/episodes/:id\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/:id/comments\\",
-  params: { id: string | number },
-  ...query: Query<import('../app/routes/admin/episodes/$id/comments').SearchParams>
+  params: Routes[\\"/admin/episodes/:id/comments\\"][\\"params\\"],
+  ...query: Routes[\\"/admin/episodes/:id/comments\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/new\\",
-  ...query: Query<import('../app/routes/admin/episodes/new').SearchParams>
+  ...query: Routes[\\"/admin/episodes/new\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/jokes\\",
-  ...query: Query<import('../app/routes/jokes').SearchParams>
+  ...query: Routes[\\"/jokes\\"][\\"query\\"]
 ): string;
 export declare function $path(
   route: \\"/jokes/:jokeId\\",
-  params: { jokeId: string | number },
-  ...query: Query<import('../app/routes/jokes/$jokeId').SearchParams>
+  params: Routes[\\"/jokes/:jokeId\\"][\\"params\\"],
+  ...query: Routes[\\"/jokes/:jokeId\\"][\\"query\\"]
 ): string;
 
 export declare function $params(

--- a/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -10,7 +10,7 @@ type IsAny<T> = (
     : false
 );
 type URLSearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams;
-type Query<T> = IsAny<T> extends true ? [URLSearchParamsInit?] : [T];
+type Query<T> = IsAny<T> extends true ? URLSearchParamsInit : T;
       
 
 export interface Routes {
@@ -102,97 +102,97 @@ export interface Routes {
 
 export declare function $path(
   route: \\"/\\",
-  ...query: Routes[\\"/\\"][\\"query\\"]
+  ...query: [Routes[\\"/\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/chats/:season/:episode/:slug\\",
   params: Routes[\\"/chats/:season/:episode/:slug\\"][\\"params\\"],
-  ...query: Routes[\\"/chats/:season/:episode/:slug\\"][\\"query\\"]
+  ...query: [Routes[\\"/chats/:season/:episode/:slug\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/chats/:season/:episode\\",
   params: Routes[\\"/chats/:season/:episode\\"][\\"params\\"],
-  ...query: Routes[\\"/chats/:season/:episode\\"][\\"query\\"]
+  ...query: [Routes[\\"/chats/:season/:episode\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/people/:personId\\",
   params: Routes[\\"/people/:personId\\"][\\"params\\"],
-  ...query: Routes[\\"/people/:personId\\"][\\"query\\"]
+  ...query: [Routes[\\"/people/:personId\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/people/:personId/:planId/remove-plan\\",
   params: Routes[\\"/people/:personId/:planId/remove-plan\\"][\\"params\\"],
-  ...query: Routes[\\"/people/:personId/:planId/remove-plan\\"][\\"query\\"]
+  ...query: [Routes[\\"/people/:personId/:planId/remove-plan\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/blog/rss.xml\\",
-  ...query: Routes[\\"/blog/rss.xml\\"][\\"query\\"]
+  ...query: [Routes[\\"/blog/rss.xml\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/:lang?/about\\",
   params: Routes[\\"/:lang?/about\\"][\\"params\\"],
-  ...query: Routes[\\"/:lang?/about\\"][\\"query\\"]
+  ...query: [Routes[\\"/:lang?/about\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/posts/delete\\",
-  ...query: Routes[\\"/posts/delete\\"][\\"query\\"]
+  ...query: [Routes[\\"/posts/delete\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/auth\\",
-  ...query: Routes[\\"/auth\\"][\\"query\\"]
+  ...query: [Routes[\\"/auth\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/auth/login\\",
-  ...query: Routes[\\"/auth/login\\"][\\"query\\"]
+  ...query: [Routes[\\"/auth/login\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/posts\\",
-  ...query: Routes[\\"/posts\\"][\\"query\\"]
+  ...query: [Routes[\\"/posts\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/posts/:id\\",
   params: Routes[\\"/posts/:id\\"][\\"params\\"],
-  ...query: Routes[\\"/posts/:id\\"][\\"query\\"]
+  ...query: [Routes[\\"/posts/:id\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/s/:query\\",
   params: Routes[\\"/s/:query\\"][\\"params\\"],
-  ...query: Routes[\\"/s/:query\\"][\\"query\\"]
+  ...query: [Routes[\\"/s/:query\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/credits\\",
-  ...query: Routes[\\"/credits\\"][\\"query\\"]
+  ...query: [Routes[\\"/credits\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/admin\\",
-  ...query: Routes[\\"/admin\\"][\\"query\\"]
+  ...query: [Routes[\\"/admin\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes\\",
-  ...query: Routes[\\"/admin/episodes\\"][\\"query\\"]
+  ...query: [Routes[\\"/admin/episodes\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/:id\\",
   params: Routes[\\"/admin/episodes/:id\\"][\\"params\\"],
-  ...query: Routes[\\"/admin/episodes/:id\\"][\\"query\\"]
+  ...query: [Routes[\\"/admin/episodes/:id\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/:id/comments\\",
   params: Routes[\\"/admin/episodes/:id/comments\\"][\\"params\\"],
-  ...query: Routes[\\"/admin/episodes/:id/comments\\"][\\"query\\"]
+  ...query: [Routes[\\"/admin/episodes/:id/comments\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/admin/episodes/new\\",
-  ...query: Routes[\\"/admin/episodes/new\\"][\\"query\\"]
+  ...query: [Routes[\\"/admin/episodes/new\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/jokes\\",
-  ...query: Routes[\\"/jokes\\"][\\"query\\"]
+  ...query: [Routes[\\"/jokes\\"][\\"query\\"]]
 ): string;
 export declare function $path(
   route: \\"/jokes/:jokeId\\",
   params: Routes[\\"/jokes/:jokeId\\"][\\"params\\"],
-  ...query: Routes[\\"/jokes/:jokeId\\"][\\"query\\"]
+  ...query: [Routes[\\"/jokes/:jokeId\\"][\\"query\\"]]
 ): string;
 
 export declare function $params(

--- a/packages/remix-routes/src/cli.ts
+++ b/packages/remix-routes/src/cli.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import chokidar from 'chokidar';
 import type { ConfigRoute } from '@remix-run/dev/dist/config/routes';
 import mkdirp from 'mkdirp';
+import slash from 'slash';
 
 let readConfig: typeof import('@remix-run/dev/dist/config').readConfig;
 
@@ -137,7 +138,7 @@ function generateRouteDefinition(routesInfo: RoutesInfo) {
       (param) => `${param}: string | number`,
     );
     lines.push(`    params: { ${paramsType.join('; ')} },`);
-    lines.push(`    query: Query<import('../app/${fileName.replace(/\.tsx?$/, '')}').SearchParams>,`)
+    lines.push(`    query: Query<import('../app/${slash(fileName.replace(/\.tsx?$/, ''))}').SearchParams>,`)
     lines.push('  };')
     code.push(lines.join('\n'));
   });

--- a/packages/typescript-remix-routes-plugin/package.json
+++ b/packages/typescript-remix-routes-plugin/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "resolve": "^1.22.0",
+    "slash": "3",
     "typescript": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/typescript-remix-routes-plugin/src/RouteHelperLanguageService.ts
+++ b/packages/typescript-remix-routes-plugin/src/RouteHelperLanguageService.ts
@@ -4,6 +4,7 @@ import { LanguageService } from './LanguageService';
 import { RemixProject } from './RemixProject';
 import { RouteContext } from './RouteContext';
 import { ScriptSourceHelper } from './ScriptSourceHelper';
+import slash from 'slash';
 
 export class RouteHelperLanguageService extends LanguageService {
   constructor(
@@ -32,7 +33,7 @@ export class RouteHelperLanguageService extends LanguageService {
             kind: ts.ScriptElementKind.string,
             kindModifiers: '',
             displayParts: routes.slice(0, 1).map((route) => ({
-              text: `(remix) file: ${path.join('~/app', route.relativeFileName)}`,
+              text: `(remix) file: ${slash(path.join('~/app', route.relativeFileName))}`,
               kind: ts.SymbolDisplayPartKind.methodName as any,
             })),
             textSpan: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,12 +47,14 @@ importers:
       meow: 9.0.0
       mkdirp: ^1.0.4
       semantic-release: ^19.0.3
+      slash: '3'
       typescript: ^4.5.3
       typescript-remix-routes-plugin: workspace:*
     dependencies:
       chokidar: 3.5.2
       meow: 9.0.0
       mkdirp: 1.0.4
+      slash: 3.0.0
       typescript-remix-routes-plugin: link:../typescript-remix-routes-plugin
     devDependencies:
       '@remix-run/dev': 1.9.0
@@ -70,11 +72,13 @@ importers:
       '@types/node': ^17.0.21
       '@types/resolve': ^1.20.2
       resolve: ^1.22.0
+      slash: '3'
       typescript: ^4.4.3
       vite: ^3.1.0
       vitest: ^0.23.2
     dependencies:
       resolve: 1.22.1
+      slash: 3.0.0
       typescript: 4.5.4
     devDependencies:
       '@remix-run/dev': 1.9.0
@@ -7642,7 +7646,6 @@ packages:
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /smart-buffer/4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}


### PR DESCRIPTION
Addresses #38 

The PR export route definitions under `Routes` interface:

```typescript
export interface Routes {
  "/": {
    params: {  },
    query: Query<import('../app/root').SearchParams>,
  };
  "/:lang?/about": {
    params: { lang?: string | number },
    query: Query<import('../app/routes/($lang)/about').SearchParams>,
  };
  "/posts": {
    params: {  },
    query: Query<import('../app/routes/posts/index').SearchParams>,
  };
  "/posts/:id": {
    params: { id: string | number },
    query: Query<import('../app/routes/posts/$id').SearchParams>,
  };
}
```