### PR TITLE
feat: introduce strict mode

### DIFF
--- a/.changeset/gentle-ears-peel.md
+++ b/.changeset/gentle-ears-peel.md
@@ -1,0 +1,5 @@
+---
+"remix-routes": minor
+---
+
+feat: introduce strict mode

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ export default function Component() {
 ## Command Line Options
 
 - `-w`: Watch for changes and automatically rebuild.
+- `-s`: Enale strict mode. In strict mode only routes that define `SearchParams` type are allowed to have query string.
 - `-o`: Specify the output path for `remix-routes.d.ts`. Defaults to `./node_modules` if arg is not given.
 
 ## TypeScript Integration

--- a/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/remix-routes/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -5,7 +5,9 @@ exports[`build v1 routes 1`] = `
   type URLSearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams;
   // symbol won't be a key of SearchParams
   type IsSearchParams<T> = symbol extends keyof T ? false : true;
-  type ExportedQuery<T> = IsSearchParams<T> extends true ? T : URLSearchParamsInit;
+  
+    type ExportedQuery<T> = IsSearchParams<T> extends true ? T : URLSearchParamsInit;
+  
 
   export interface Routes {
   
@@ -229,7 +231,9 @@ exports[`build v2 routes 1`] = `
   type URLSearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams;
   // symbol won't be a key of SearchParams
   type IsSearchParams<T> = symbol extends keyof T ? false : true;
-  type ExportedQuery<T> = IsSearchParams<T> extends true ? T : URLSearchParamsInit;
+  
+    type ExportedQuery<T> = IsSearchParams<T> extends true ? T : URLSearchParamsInit;
+  
 
   export interface Routes {
   

--- a/packages/remix-routes/src/__tests__/cli.test.ts
+++ b/packages/remix-routes/src/__tests__/cli.test.ts
@@ -4,14 +4,14 @@ import * as path from 'path';
 import { build } from '../cli';
 
 test('build v1 routes', async () => {
-  await build(path.resolve(__dirname, '../../fixture/v1'), './node_modules');
+  await build(path.resolve(__dirname, '../../fixture/v1'), { outputDirPath: './node_modules', watch: false, strict: false });
   expect(
     fs.readFileSync(path.resolve(__dirname, '../../fixture/v1/node_modules/remix-routes.d.ts'), 'utf8'),
   ).toMatchSnapshot();
 });
 
 test('build v2 routes', async () => {
-  await build(path.resolve(__dirname, '../../fixture/v2'), './node_modules');
+  await build(path.resolve(__dirname, '../../fixture/v2'), { outputDirPath: './node_modules', watch: false, strict: false });
   expect(
     fs.readFileSync(path.resolve(__dirname, '../../fixture/v2/node_modules/remix-routes.d.ts'), 'utf8'),
   ).toMatchSnapshot();

--- a/packages/remix-routes/src/template.ts
+++ b/packages/remix-routes/src/template.ts
@@ -2,7 +2,11 @@ export const template = `declare module "remix-routes" {
   type URLSearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams;
   // symbol won't be a key of SearchParams
   type IsSearchParams<T> = symbol extends keyof T ? false : true;
-  type ExportedQuery<T> = IsSearchParams<T> extends true ? T : URLSearchParamsInit;
+  <% if (strictMode) { %>
+    type ExportedQuery<T> = IsSearchParams<T> extends true ? T : never;
+  <% } else { %>
+    type ExportedQuery<T> = IsSearchParams<T> extends true ? T : URLSearchParamsInit;
+  <% } %>
 
   export interface Routes {
   <% routes.forEach(({ route, params, fileName }) => { %>


### PR DESCRIPTION
This PR introduces a strict mode behind the `-s` flag. In strict mode, only routes defined the `SearchParams` can accept search params.

Close #57