### PR TITLE
docs: modify README to use params helper on client

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,12 @@ export const action: ActionFunction = async ({ params }) => {
 remix-routes also export all route type definitions for your convenience.
 
 ```typescript
-import type { Routes } from 'remix-routes';
 import { useParams } from "remix";
+import { $params } from 'remix-routes';
 
 export default function Component() {
-  const { id } = useParams<Routes['/posts/:id']['params']>();
+  const params = useParams();
+  const { id } = $params("/posts/:id", params);
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ export const loader = async (request) => {
 
 ```typescript
 import type { ActionFunction } from 'remix';
+import { useParams } from "remix";
 import { $params } from 'remix-routes'; // <-- Import $params helper.
 
 export const action: ActionFunction = async ({ params }) => {
@@ -147,19 +148,10 @@ export const action: ActionFunction = async ({ params }) => {
 
   // ...
 }
-```
-
-### Route type definitions
-
-remix-routes also export all route type definitions for your convenience.
-
-```typescript
-import { useParams } from "remix";
-import { $params } from 'remix-routes';
 
 export default function Component() {
   const params = useParams();
-  const { id } = $params("/posts/:id", params);
+  const { id } = $params("/posts/:id/update", params);
   ...
 }
 ```


### PR DESCRIPTION
## Overview

https://github.com/yesmeck/remix-routes/issues/80

Fixed the documentation to use the `$params` helper to retrieve dynamic route parameters on the client side.