### PR TITLE
ignore undefined path params

### DIFF
--- a/packages/remix-routes/src/__tests__/index.test.ts
+++ b/packages/remix-routes/src/__tests__/index.test.ts
@@ -30,6 +30,7 @@ test('$path + params + query', () => {
 
 test('$path + optional route fragment', () => {
   expect($path('/:lang?/about', {})).toBe('/about');
+  expect($path('/:lang?/about', { lang: undefined })).toBe('/about');
   expect($path('/:lang?/about', { lang: 'en' })).toBe('/en/about');
 });
 

--- a/packages/remix-routes/src/index.ts
+++ b/packages/remix-routes/src/index.ts
@@ -20,7 +20,7 @@ export function $path(route: string, ...paramsOrQuery: Array<any>) {
       }
       if (fragment.indexOf(':') > -1) {
         let paramName = fragment.slice(1);
-        if (paramName in params) {
+        if (paramName in params && params[paramName] !== undefined) {
           return params[paramName];
         }
         return null


### PR DESCRIPTION
Optional path params can be omitted or passed as `undefined`. In the former case the param segment is dropped from the output but in the latter it is not, resulting in an empty path segment (`//`) which remix does not accept. 
This behaviour is unexpected IMO and requires funky handling to avoid defining the param key when you want to use a possibly-undefined variable for the value, eg:
```ts
$path('/:lang?/about'), { ...(language ? { lang: language } : undefined) })
```

**Demo**

Example input
```ts
$path('/:lang?/about', {})
$path('/:lang?/about', { lang: undefined })
```

Output before this change
```
/about
//about
```

Output after this change
```
/about
/about
```