### PR TITLE
fix: directory not empty when running react-router with vite

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import { createContext } from './vite-node.js';
 
 async function run() {
-  process.env.SAFE_ROUTES_CLI = 'true';
   const { runner, server } = await createContext();
   await runner.executeFile(path.resolve(import.meta.dirname, '../dist/empty.js'));
   await server.close();

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -67,9 +67,7 @@ export function safeRoutes(pluginConfig: PluginOptions = {}): Vite.Plugin {
       ctx = extractReactRouterPluginContext(config);
     },
     async configureServer() {
-      if (process.env.SAFE_ROUTES_CLI) {
-        await reactRouterPlugin.buildEnd();
-      }
+      await reactRouterPlugin.buildEnd();
       generateTypeFile();
     },
     async watchChange(id) {


### PR DESCRIPTION
The fix from [this PR](https://github.com/yesmeck/safe-routes/pull/148) focuses on the CLI but the issue also happens when running react-router in dev with vite.

This PR should fix this issue as well https://github.com/yesmeck/safe-routes/issues/149