### PR TITLE
fix: normalize basename path joins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@ function includesParams(route: string) {
 
 function prependBasename(path: string) {
   const basename = resolveBasename();
-  if (!basename) {
+  if (!basename || basename === '/') {
     return path;
   }
-  return basename + path;
+  return `${basename.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
 }
 
 export function $path(route: string, ...paramsOrQuery: Array<any>) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -62,3 +62,15 @@ test('basename', async () => {
 
   expect($path('/posts')).toBe("/blog/posts");
 });
+
+test('root basename', async () => {
+  vi.mocked(basename.resolveBasename).mockReturnValue('/');
+
+  expect($path('/posts')).toBe('/posts');
+});
+
+test('basename with trailing slash', async () => {
+  vi.mocked(basename.resolveBasename).mockReturnValue('/blog/');
+
+  expect($path('/posts')).toBe('/blog/posts');
+});


### PR DESCRIPTION
## Summary
- Treat a root basename (`/`) as no basename when generating paths.
- Normalize basename/path joins so trailing and leading slashes do not produce `//` URLs.
- Add tests for root basename and trailing-slash basename behavior.

## Test plan
- `pnpm test tests/index.test.ts --run`
- `pnpm build`
- `pnpm test --run` was attempted; all 17 test assertions passed after temporarily installing missing React Router/React peers, but Vitest still exited nonzero due to an upstream e2e fixture unhandled async typegen ENOENT after cleanup.

Made with [Cursor](https://cursor.com)